### PR TITLE
WIP: Operation lookahead and merging, and more complex nested modifier operations.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,9 @@ travis-ci = { repository = "jonhoo/rust-evmap" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-hashbrown = { version = "0.1.8", optional = true }
-smallvec = { version = "0.6.7", optional = true }
+hashbrown = { version = "0.1.8" }
+smallvec = { version = "0.6.7" }
 
 [features]
-default = ["hashbrown", "smallvec"]
 nightly_hashbrown = ["hashbrown/nightly"]
 nightly_smallvec = ["smallvec/union", "smallvec/may_dangle", "smallvec/specialization"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,6 @@ hashbrown = { version = "0.1.8" }
 smallvec = { version = "0.6.7", optional = true }
 
 [features]
+default = ["smallvec"]
 nightly = ["hashbrown/nightly"]
 nightly_smallvec = ["smallvec/union", "smallvec/may_dangle", "smallvec/specialization"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 hashbrown = { version = "0.1.8" }
-smallvec = { version = "0.6.7" }
+smallvec = { version = "0.6.7", optional = true }
 
 [features]
-nightly = ["hashbrown/nightly", "smallvec/union", "smallvec/may_dangle", "smallvec/specialization"]
+nightly = ["hashbrown/nightly"]
+nightly_smallvec = ["smallvec/union", "smallvec/may_dangle", "smallvec/specialization"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,4 @@ hashbrown = { version = "0.1.8" }
 smallvec = { version = "0.6.7" }
 
 [features]
-nightly_hashbrown = ["hashbrown/nightly"]
-nightly_smallvec = ["smallvec/union", "smallvec/may_dangle", "smallvec/specialization"]
+nightly = ["hashbrown/nightly", "smallvec/union", "smallvec/may_dangle", "smallvec/specialization"]

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -1,16 +1,8 @@
 use std::hash::{BuildHasher, Hash};
 use std::sync::{atomic, Arc, Mutex};
 
-#[cfg(not(feature = "hashbrown"))]
-use std::collections::HashMap;
-
-#[cfg(feature = "hashbrown")]
 use hashbrown::HashMap;
 
-#[cfg(not(feature = "smallvec"))]
-pub(crate) type Values<T> = Vec<T>;
-
-#[cfg(feature = "smallvec")]
 pub(crate) type Values<T> = smallvec::SmallVec<[T; 1]>;
 
 pub(crate) struct Inner<K, V, M, S>

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -3,7 +3,11 @@ use std::sync::{atomic, Arc, Mutex};
 
 use hashbrown::HashMap;
 
+#[cfg(feature = "smallvec")]
 pub(crate) type Values<T> = smallvec::SmallVec<[T; 1]>;
+
+#[cfg(not(feature = "smallvec"))]
+pub(crate) type Values<T> = Vec<T>;
 
 pub(crate) struct Inner<K, V, M, S>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,8 @@
 #![deny(missing_docs)]
 
 extern crate hashbrown;
+
+#[cfg(feature = "smallvec")]
 extern crate smallvec;
 
 /// Re-export default FxHash hash builder from `hashbrown`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,8 +183,7 @@
 //! writing.
 //!
 
-//#![deny(missing_docs)]
-#![allow(dead_code)]
+#![deny(missing_docs)]
 
 extern crate hashbrown;
 extern crate smallvec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,105 +182,24 @@
 //! approximately twice of that of a regular `HashMap`, and more if writes rarely refresh after
 //! writing.
 //!
-//! # Small Vector Optimization
-//!
-//! By default, the value-set for each key in the map uses the `smallvec` crate to keep a
-//! maximum of one element stored inline with the map, as opposed to separately heap-allocated
-//! with a plain `Vec`. Operations such as `Fit` and `Replace` will automatically switch
-//! back to the inline storage if possible. This is ideal for maps that mostly use one
-//! element per key, as it can improvate memory locality with less indirection.
-//!
-//! If this is undesirable, simple set:
-//!
-//! ```toml
-//! default-features = false
-//! ```
-//!
-//! in the `evmap` dependency entry, and `Vec` will always be used internally.
-//!
-//! Note that this will also opt out of the `hashbrown` dependency, which is usually preferred,
-//! so add that back with:
-//!
-//! ```toml
-//! features = ["hashbrown"]
-//! ```
-//!
-#![deny(missing_docs)]
 
-#[cfg(feature = "hashbrown")]
+//#![deny(missing_docs)]
+#![allow(dead_code)]
+
 extern crate hashbrown;
-
-#[cfg(feature = "smallvec")]
 extern crate smallvec;
 
 /// Re-export default FxHash hash builder from `hashbrown`
-#[cfg(feature = "hashbrown")]
 pub type FxHashBuilder = hashbrown::hash_map::DefaultHashBuilder;
 
 use std::collections::hash_map::RandomState;
-use std::fmt;
 use std::hash::{BuildHasher, Hash};
-use std::sync::Arc;
 
 mod inner;
 use inner::Inner;
 
-/// Unary predicate used to retain elements
-#[derive(Clone)]
-pub struct Predicate<V>(pub(crate) Arc<Fn(&V) -> bool + Send + Sync>);
-
-impl<V> Predicate<V> {
-    /// Evaluate the predicate for the given element
-    #[inline]
-    pub fn eval(&self, value: &V) -> bool {
-        (*self.0)(value)
-    }
-}
-
-impl<V> PartialEq for Predicate<V> {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.0, &other.0)
-    }
-}
-
-impl<V> Eq for Predicate<V> {}
-
-impl<V> fmt::Debug for Predicate<V> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Predicate")
-            .field(&format_args!("{:p}", &*self.0 as *const _))
-            .finish()
-    }
-}
-
-/// A pending map operation.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum Operation<K, V> {
-    /// Replace the set of entries for this key with this value.
-    Replace(K, V),
-    /// Add this value to the set of entries for this key.
-    Add(K, V),
-    /// Remove this value from the set of entries for this key.
-    Remove(K, V),
-    /// Remove the value set for this key.
-    Empty(K),
-    /// Remove all values in the value set for this key.
-    Clear(K),
-    /// Retains all values matching the given predicate.
-    Retain(K, Predicate<V>),
-    /// Shrinks a value-set to it's minimum necessary size, freeing memory
-    /// and potentially improving cache locality if the `smallvec` feature is used.
-    ///
-    /// If no key is given, all value-sets will shrink to fit.
-    Fit(Option<K>),
-    /// Reserves capacity for some number of additional elements in a value-set,
-    /// or creates an empty value-set for this key with the given capacity if
-    /// it doesn't already exist.
-    ///
-    /// This can improve performance by pre-allocating space for large value-sets.
-    Reserve(K, usize),
-}
+pub mod op;
+pub use op::Operation;
 
 mod write;
 pub use write::WriteHandle;

--- a/src/op.rs
+++ b/src/op.rs
@@ -164,9 +164,9 @@ pub(crate) struct MarkedOperation<K, V> {
     pub flag: Cell<u32>,
 }
 
-const NONE_FLAG: u32 = 0b0000; // 0, value has not been used at all
-const FIRST_FLAG: u32 = 0b001; // 1 << 0, value has been used without consuming
-const SECOND_FLAG: u32 = 0b10; // 1 << 1, value has been consumed
+const NONE_FLAG: u32 = 0; // value has not been used at all
+const FIRST_FLAG: u32 = 1; // value has been used without consuming
+const SECOND_FLAG: u32 = 2; // value has been consumed
 
 impl<K, V> Drop for MarkedOperation<K, V> {
     fn drop(&mut self) {
@@ -180,10 +180,7 @@ impl<K, V> Drop for MarkedOperation<K, V> {
     }
 }
 
-impl<K, V> MarkedOperation<K, V>
-where
-    K: PartialEq,
-{
+impl<K, V> MarkedOperation<K, V> {
     #[inline]
     pub fn new(op: Operation<K, V>) -> Self {
         MarkedOperation {

--- a/src/op.rs
+++ b/src/op.rs
@@ -161,12 +161,12 @@ pub enum Operation<K, V> {
 /// inner operation, while the second consumes it and renders it unreadable again.
 pub(crate) struct MarkedOperation<K, V> {
     pub op: mem::ManuallyDrop<UnsafeCell<Operation<K, V>>>,
-    pub flag: Cell<u32>,
+    pub flag: Cell<u8>,
 }
 
-const NONE_FLAG: u32 = 0; // value has not been used at all
-const FIRST_FLAG: u32 = 1; // value has been used without consuming
-const SECOND_FLAG: u32 = 2; // value has been consumed
+const NONE_FLAG: u8 = 0; // value has not been used at all
+const FIRST_FLAG: u8 = 1; // value has been used without consuming
+const SECOND_FLAG: u8 = 2; // value has been consumed
 
 impl<K, V> Drop for MarkedOperation<K, V> {
     fn drop(&mut self) {

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,0 +1,640 @@
+use std::borrow::Cow;
+use std::cell::{Cell, UnsafeCell};
+use std::hash::{BuildHasher, Hash};
+use std::ops::Deref;
+use std::sync::Arc;
+use std::{fmt, mem, ptr};
+
+use hashbrown::hash_map::RawEntryMut;
+use smallvec::SmallVec;
+
+use super::ShallowCopy;
+use inner::{Inner, Values};
+
+/// Unary predicate used to retain elements
+pub struct Predicate<V>(pub(crate) Arc<Fn(&V) -> bool + Send + Sync>);
+
+impl<V> Predicate<V> {
+    /// Evaluate the predicate for the given element
+    #[inline]
+    pub fn eval(&self, value: &V) -> bool {
+        (*self.0)(value)
+    }
+}
+
+impl<V> Clone for Predicate<V> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Predicate(self.0.clone())
+    }
+}
+
+impl<V> PartialEq for Predicate<V> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl<V> Eq for Predicate<V> {}
+
+impl<V> fmt::Debug for Predicate<V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Predicate")
+            .field(&format_args!("{:p}", &*self.0 as *const _))
+            .finish()
+    }
+}
+
+pub struct Modifier<V>(pub(crate) Arc<for<'a> Fn(&mut Modify<'a, V>) + Send + Sync>);
+
+impl<V> Modifier<V> {
+    #[inline]
+    pub fn modify(&self, value: &mut Modify<V>) {
+        (*self.0)(value)
+    }
+}
+
+impl<V> Clone for Modifier<V> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Modifier(self.0.clone())
+    }
+}
+
+impl<V> PartialEq for Modifier<V> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl<V> Eq for Modifier<V> {}
+
+impl<V> fmt::Debug for Modifier<V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Modifier")
+            .field(&format_args!("{:p}", &*self.0 as *const _))
+            .finish()
+    }
+}
+
+/// A pending map operation.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ValueOperation<V> {
+    /// Replace the set of entries for this key with this value.
+    Replace(V),
+    /// Add this value to the set of entries for this key.
+    Add(V),
+    /// Remove this value from the set of entries for this key, without preserving the
+    /// order of elements in the value-set
+    Remove(V),
+
+    /// Remove this value from the set of entries for this key, preserving order of the
+    /// elements in the value-set
+    RemoveStable(V),
+
+    /// Remove all values in the value set for this key.
+    Clear,
+
+    /// Remove the value set for this key.
+    Empty,
+
+    /// Retains all values matching the given predicate.
+    Retain(Predicate<V>),
+    /// Shrinks a value-set to it's minimum necessary size, freeing memory
+    /// and potentially improving cache locality.
+    ///
+    /// If no key is given, all value-sets will shrink to fit.
+    Fit,
+    /// Reserves capacity for some number of additional elements in a value-set,
+    /// or creates an empty value-set for this key with the given capacity if
+    /// it doesn't already exist.
+    ///
+    /// This can improve performance by pre-allocating space for large value-sets.
+    Reserve(usize),
+
+    Modify(Modifier<V>),
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum MapOperation<V> {
+    /// Applies `Fit` to all value-sets
+    FitAll,
+
+    /// Removes empty value-sets from the map
+    Prune,
+
+    /// Test
+    ForEach(Modifier<V>),
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Operation<K, V> {
+    Value { key: K, op: ValueOperation<V> },
+    Map { op: MapOperation<V> },
+}
+
+/// The concept for this is that the "first" version can only borrow the data,
+/// while the "second" version can consume it permenenantly.
+///
+/// However, they have to work together and sometimes overlap. Therefore,
+/// it must be possible to do both, in any order.
+///
+/// It does this through two flags, where the first simply mutably borrows the
+/// inner operation, while the second consumes it and renders it unreadable again.
+pub(crate) struct MarkedOperation<K, V> {
+    pub op: mem::ManuallyDrop<UnsafeCell<Operation<K, V>>>,
+    pub flag: Cell<u32>,
+}
+
+const NONE_FLAG: u32 = 0b0000; // 0, value has not been used at all
+const FIRST_FLAG: u32 = 0b001; // 1 << 0, value has been used without consuming
+const SECOND_FLAG: u32 = 0b10; // 1 << 1, value has been consumed
+
+impl<K, V> Drop for MarkedOperation<K, V> {
+    fn drop(&mut self) {
+        // If the operation hasn't been consumed, drop it
+        match self.flag.get() {
+            NONE_FLAG | FIRST_FLAG => unsafe {
+                mem::ManuallyDrop::drop(&mut self.op);
+            },
+            _ => {}
+        }
+    }
+}
+
+impl<K, V> MarkedOperation<K, V>
+where
+    K: PartialEq,
+{
+    #[inline]
+    pub fn new(op: Operation<K, V>) -> Self {
+        MarkedOperation {
+            op: mem::ManuallyDrop::new(UnsafeCell::new(op)),
+            flag: Cell::new(NONE_FLAG),
+        }
+    }
+
+    #[inline(always)]
+    pub fn mark_first(&self) {
+        self.flag.set(FIRST_FLAG);
+    }
+
+    #[inline(always)]
+    pub fn mark_second(&self) {
+        self.flag.set(SECOND_FLAG);
+    }
+
+    #[inline(always)]
+    pub fn consumed(&self) -> bool {
+        self.flag.get() == SECOND_FLAG
+    }
+
+    #[inline(always)]
+    pub fn as_ref(&self) -> Option<&Operation<K, V>> {
+        match self.flag.get() {
+            NONE_FLAG => Some(unsafe { &*self.op.get() }),
+            _ => None,
+        }
+    }
+
+    pub fn as_mut(&self) -> Option<&mut Operation<K, V>> {
+        match self.flag.get() {
+            NONE_FLAG => Some(unsafe { &mut *self.op.get() }),
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    pub fn take_first(&self) -> Option<&mut Operation<K, V>> {
+        match self.flag.get() {
+            NONE_FLAG => {
+                self.flag.set(FIRST_FLAG);
+
+                Some(unsafe { &mut *self.op.get() })
+            }
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    pub fn take_second(&self) -> Option<Operation<K, V>> {
+        match self.flag.get() {
+            SECOND_FLAG => None,
+            _ => {
+                self.flag.set(SECOND_FLAG);
+
+                Some(unsafe { ptr::read(self.op.get()) })
+            }
+        }
+    }
+}
+
+impl<V> MapOperation<V>
+where
+    V: PartialEq + ShallowCopy,
+{
+    pub(crate) fn apply_first<K, M, S>(&mut self, inner: &mut Inner<K, V, M, S>)
+    where
+        K: Eq + Hash,
+        S: BuildHasher,
+    {
+        match *self {
+            MapOperation::FitAll => {
+                for vs in inner.data.values_mut() {
+                    vs.shrink_to_fit();
+                }
+            }
+            MapOperation::Prune => {
+                inner.data.retain(|_, vs| !vs.is_empty());
+            }
+            MapOperation::ForEach(ref modifier) => {
+                for vs in inner.data.values_mut() {
+                    let mut modify = Modify::new(vs);
+
+                    modifier.modify(&mut modify);
+
+                    modify.apply_first();
+                }
+            }
+        }
+    }
+
+    pub(crate) fn apply_second<K, M, S>(self, inner: &mut Inner<K, V, M, S>)
+    where
+        K: Eq + Hash,
+        S: BuildHasher,
+    {
+        match self {
+            MapOperation::FitAll => {
+                for vs in inner.data.values_mut() {
+                    vs.shrink_to_fit();
+                }
+            }
+            MapOperation::Prune => {
+                inner.data.retain(|_, vs| !vs.is_empty());
+            }
+            MapOperation::ForEach(modifier) => {
+                for vs in inner.data.values_mut() {
+                    let mut modify = Modify::new(vs);
+
+                    modifier.modify(&mut modify);
+
+                    modify.apply_second();
+                }
+            }
+        }
+    }
+}
+
+pub struct Modify<'a, V> {
+    ops: SmallVec<[ValueOperation<V>; 1]>,
+    values: &'a mut Values<V>,
+}
+
+impl<'a, V> Deref for Modify<'a, V> {
+    type Target = [V];
+
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
+}
+
+impl<'a, V> Modify<'a, V>
+where
+    V: PartialEq + ShallowCopy,
+{
+    fn new(values: &'a mut Values<V>) -> Self {
+        Modify {
+            ops: SmallVec::new(),
+            values,
+        }
+    }
+
+    fn apply_first(&mut self) {
+        let Modify {
+            ref mut ops,
+            values,
+        } = self;
+
+        for op in ops {
+            match *op {
+                ValueOperation::Replace(ref mut value) => {
+                    unsafe {
+                        values.set_len(0);
+                    }
+
+                    values.shrink_to_fit();
+                    values.push(unsafe { value.shallow_copy() });
+                }
+                ValueOperation::Clear => unsafe { values.set_len(0) },
+                ValueOperation::Add(ref mut value) => {
+                    values.push(unsafe { value.shallow_copy() });
+                }
+                ValueOperation::Remove(ref value) => {
+                    if let Some(i) = values.iter().position(|v| v == value) {
+                        mem::forget(values.swap_remove(i));
+                    }
+                }
+                ValueOperation::RemoveStable(ref value) => {
+                    if let Some(i) = values.iter().position(|v| v == value) {
+                        mem::forget(values.remove(i));
+                    }
+                }
+                ValueOperation::Retain(ref predicate) => {
+                    let mut del = 0;
+                    let len = values.len();
+
+                    // See the comments on the primary implementation for more info on this
+                    for i in 0..len {
+                        if !predicate.eval(unsafe { values.get_unchecked(i) }) {
+                            del += 1;
+                        } else {
+                            values.swap(i - del, i);
+                        }
+                    }
+
+                    unsafe {
+                        values.set_len(len - del);
+                    }
+                }
+                ValueOperation::Fit => values.shrink_to_fit(),
+                ValueOperation::Reserve(additional) => values.reserve(additional),
+
+                // Not even allowed to be added
+                ValueOperation::Modify(_) | ValueOperation::Empty => unimplemented!(),
+            }
+        }
+    }
+
+    fn apply_second(self) {
+        let Modify { ops, values } = self;
+
+        for op in ops {
+            match op {
+                ValueOperation::Replace(value) => {
+                    values.clear();
+                    values.shrink_to_fit();
+                    values.push(value);
+                }
+                ValueOperation::Clear => values.clear(),
+                ValueOperation::Add(value) => values.push(value),
+                ValueOperation::Remove(value) => {
+                    if let Some(i) = values.iter().position(|v| v == &value) {
+                        mem::drop(values.swap_remove(i));
+                    }
+                }
+                ValueOperation::RemoveStable(value) => {
+                    if let Some(i) = values.iter().position(|v| v == &value) {
+                        mem::drop(values.remove(i));
+                    }
+                }
+                ValueOperation::Retain(predicate) => values.retain(|v| predicate.eval(v)),
+                ValueOperation::Fit => values.shrink_to_fit(),
+                ValueOperation::Reserve(additional) => values.reserve(additional),
+
+                // Not even allowed to be added
+                ValueOperation::Modify(_) | ValueOperation::Empty => unimplemented!(),
+            }
+        }
+    }
+
+    #[inline]
+    fn add_op(&mut self, op: ValueOperation<V>) -> &mut Self {
+        self.ops.push(op);
+        self
+    }
+
+    #[inline]
+    pub fn replace(&mut self, value: V) -> &mut Self {
+        self.add_op(ValueOperation::Replace(value))
+    }
+
+    #[inline]
+    pub fn clear(&mut self) -> &mut Self {
+        self.add_op(ValueOperation::Clear)
+    }
+
+    #[inline]
+    pub fn add(&mut self, value: V) -> &mut Self {
+        self.add_op(ValueOperation::Add(value))
+    }
+
+    #[inline]
+    pub fn remove(&mut self, value: V) -> &mut Self {
+        self.add_op(ValueOperation::Remove(value))
+    }
+
+    #[inline]
+    pub fn remove_stable(&mut self, value: V) -> &mut Self {
+        self.add_op(ValueOperation::RemoveStable(value))
+    }
+
+    #[inline]
+    pub fn retain<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(&V) -> bool + 'static + Send + Sync,
+    {
+        self.add_op(ValueOperation::Retain(Predicate(Arc::new(f))))
+    }
+
+    #[inline]
+    pub fn fit(&mut self) -> &mut Self {
+        self.add_op(ValueOperation::Fit)
+    }
+
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) -> &mut Self {
+        self.add_op(ValueOperation::Reserve(additional))
+    }
+}
+
+impl<V> ValueOperation<V>
+where
+    V: Eq + ShallowCopy,
+{
+    pub(crate) fn apply_first<K, S>(&mut self, key: Cow<K>, entry: RawEntryMut<K, Values<V>, S>)
+    where
+        K: Hash + Clone,
+        S: BuildHasher,
+    {
+        match *self {
+            ValueOperation::Remove(ref value) => {
+                if let RawEntryMut::Occupied(mut entry) = entry {
+                    let values = entry.get_mut();
+
+                    if let Some(i) = values.iter().position(|v| v == value) {
+                        mem::forget(values.swap_remove(i));
+                    }
+                }
+            }
+            ValueOperation::RemoveStable(ref value) => {
+                if let RawEntryMut::Occupied(mut entry) = entry {
+                    let values = entry.get_mut();
+
+                    if let Some(i) = values.iter().position(|v| v == value) {
+                        mem::forget(values.remove(i));
+                    }
+                }
+            }
+            ValueOperation::Empty => {
+                if let RawEntryMut::Occupied(entry) = entry {
+                    entry.remove();
+                }
+            }
+            ValueOperation::Retain(ref predicate) => {
+                if let RawEntryMut::Occupied(mut entry) = entry {
+                    let e = entry.get_mut();
+
+                    let mut del = 0;
+                    let len = e.len();
+
+                    // "bubble up" the values we wish to remove, so they can be truncated.
+                    //
+                    // See https://github.com/servo/rust-smallvec/blob/a775b5f74cce0d3c7218608fd9f6fd721bb0f461/lib.rs#L881-L897
+                    // for SmallVec's implementation of `retain`, the only difference being that we
+                    // cannot drop values here, so they are truncated with `set_len`
+                    for i in 0..len {
+                        if !predicate.eval(unsafe { e.get_unchecked(i) }) {
+                            del += 1;
+                        } else {
+                            e.swap(i - del, i);
+                        }
+                    }
+
+                    unsafe {
+                        // truncate vector without dropping values
+                        e.set_len(len - del);
+                    }
+                }
+            }
+            ValueOperation::Fit => {
+                if let RawEntryMut::Occupied(mut entry) = entry {
+                    entry.get_mut().shrink_to_fit();
+                }
+            }
+            ValueOperation::Reserve(additional) => match entry {
+                RawEntryMut::Occupied(mut entry) => {
+                    entry.get_mut().reserve(additional);
+                }
+                RawEntryMut::Vacant(entry) => {
+                    entry.insert(key.into_owned(), Values::with_capacity(additional));
+                }
+            },
+            // Fall through to operations that can use a single `or_insert_with`
+            ValueOperation::Replace(_)
+            | ValueOperation::Clear
+            | ValueOperation::Add(_)
+            | ValueOperation::Modify(_) => {
+                let (_, v) = entry.or_insert_with(|| (key.into_owned(), Values::new()));
+
+                match self {
+                    ValueOperation::Replace(ref mut value) => {
+                        unsafe {
+                            // truncate vector without dropping values
+                            v.set_len(0);
+                        }
+
+                        v.shrink_to_fit();
+                        v.push(unsafe { value.shallow_copy() });
+                    }
+                    ValueOperation::Clear => unsafe {
+                        // truncate vector without dropping values
+                        v.set_len(0);
+                    },
+                    ValueOperation::Add(ref mut value) => {
+                        v.push(unsafe { value.shallow_copy() });
+                    }
+                    ValueOperation::Modify(modifier) => {
+                        let mut modify = Modify::new(v);
+
+                        modifier.modify(&mut modify);
+
+                        modify.apply_first();
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    pub(crate) fn apply_second<K, S>(self, key: Cow<K>, entry: RawEntryMut<K, Values<V>, S>)
+    where
+        K: Hash + Clone,
+        S: BuildHasher,
+    {
+        match self {
+            ValueOperation::Remove(value) => {
+                if let RawEntryMut::Occupied(mut entry) = entry {
+                    let values = entry.get_mut();
+
+                    if let Some(i) = values.iter().position(|v| v == &value) {
+                        mem::drop(values.swap_remove(i));
+                    }
+                }
+            }
+            ValueOperation::RemoveStable(value) => {
+                if let RawEntryMut::Occupied(mut entry) = entry {
+                    let values = entry.get_mut();
+
+                    if let Some(i) = values.iter().position(|v| v == &value) {
+                        mem::drop(values.remove(i));
+                    }
+                }
+            }
+            ValueOperation::Empty => {
+                if let RawEntryMut::Occupied(entry) = entry {
+                    entry.remove();
+                }
+            }
+            ValueOperation::Retain(predicate) => {
+                if let RawEntryMut::Occupied(mut entry) = entry {
+                    entry.get_mut().retain(|v| predicate.eval(v));
+                }
+            }
+            ValueOperation::Fit => {
+                if let RawEntryMut::Occupied(mut entry) = entry {
+                    entry.get_mut().shrink_to_fit();
+                }
+            }
+            ValueOperation::Reserve(additional) => match entry {
+                RawEntryMut::Occupied(mut entry) => {
+                    entry.get_mut().reserve(additional);
+                }
+                RawEntryMut::Vacant(entry) => {
+                    entry.insert(key.into_owned(), Values::with_capacity(additional));
+                }
+            },
+            // Fall through to operations that can use a single `or_insert_with`
+            ValueOperation::Replace(_)
+            | ValueOperation::Clear
+            | ValueOperation::Add(_)
+            | ValueOperation::Modify(_) => {
+                let (_, v) = entry.or_insert_with(|| (key.into_owned(), Values::new()));
+
+                match self {
+                    ValueOperation::Replace(value) => {
+                        v.clear();
+                        v.shrink_to_fit();
+                        v.push(value);
+                    }
+                    ValueOperation::Clear => {
+                        v.clear();
+                    }
+                    ValueOperation::Add(value) => {
+                        v.push(value);
+                    }
+                    ValueOperation::Modify(modifier) => {
+                        let mut modify = Modify::new(v);
+
+                        modifier.modify(&mut modify);
+
+                        modify.apply_second();
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+}

--- a/src/write.rs
+++ b/src/write.rs
@@ -396,8 +396,8 @@ where
     ///
     /// Note that until the *first* call to `refresh`, the sequence of operations is always empty.
     ///
-    /// ```ignore
-    /// # use evmap::Operation;
+    /// ```
+    /// # use evmap::{Operation, op::ValueOperation};
     /// let x = ('x', 42);
     ///
     /// let (r, mut w) = evmap::new();
@@ -406,11 +406,27 @@ where
     /// w.refresh();
     ///
     /// assert_eq!(w.pending().count(), 0);
+    ///
     /// w.insert(x.0, x);
-    /// assert_eq!(w.pending().next(), Some(&Operation::Add(x.0, x)));
+    /// assert_eq!(
+    ///     w.pending().next(),
+    ///     Some(&Operation::Value {
+    ///         key: x.0,
+    ///         op: ValueOperation::Add(x)
+    ///     })
+    /// );
+    ///
     /// w.refresh();
+    ///
     /// w.remove(x.0, x);
-    /// assert_eq!(w.pending().next(), Some(&Operation::Remove(x.0, x)));
+    /// assert_eq!(
+    ///     w.pending().next(),
+    ///     Some(&Operation::Value {
+    ///         key: x.0,
+    ///         op: ValueOperation::Remove(x)
+    ///     })
+    /// );
+    ///
     /// w.refresh();
     /// assert_eq!(w.pending().count(), 0);
     /// ```


### PR DESCRIPTION
This PR does the following:

  1. Splits operations into two types: `MapOperation` and `ValueOperation`, and uses them within a single parent `Operation` enum like so:
     
     ```rust
     pub enum Operation<K, V> {
         Value { key: K, op: ValueOperation<V> },
         Map { op: MapOperation<V> }.
     }
     ```
     
     splitting the operation types in this way allows for easy access to the key value, which is important for:

  2. Cache key hashes and look ahead in the operation log to eagerly apply operations for same-key value-sets without having to rehash every time.
     
     For keys with non-trivial hashes or complex hashing algorithms, this can avoid much unnecessary rehashing. 
     
     This uses the `hashbrown` Raw Entry API, which does exist in `std::collections::hash_map::HashMap`, but is stuck on nightly Rust for now. Therefore, hashbrown is now a non-optional feature.
     
Furthermore, a new kind of operation was introduced:

  3. Arbitrary `Modify` and `ForEach` operations which are allowed to the the (potentially aliased) data in the value-sets *while* applying modifications to them.
     
     Example:
     
     ```rust
     w.modify(some_key, |vs| {
         let first = {
             let vs: &[i32] = unsafe { vs.get() };
     
             vs.first().unwrap_or(0);
         };
     
         if first < 10 {
             vs.replace(20);
         }
     
         vs.insert(10).insert(11).insert(12).fit();
     });
     ```

     This gives much more flexibility. It has been made `unsafe` to access the existing value-set, as it could be accessing potentially aliased data. This use of `unsafe` is simply a warning flag for the user, and a note has been made in the documentation that no attempt to clone these values should be made. It is purely for those very rare cases where such dynamic logic is necessary.
     
     However, even without using the above, this provides a way to apply many operations to a single value-set with almost no overhead whatsoever. It requires only a single key hash and single table lookup.

  4. Adds a few extra operations in addition to `Modify`/`ForEach`:
     
     * `MapOperation::Prune`, which removes empty value-sets from the map.
     * `ValueOperation::RemoveStable`, which removes a single value from a value-set without affecting the order of elements, at the cost of being slower.
         * This is opposed to `ValueOperation::Remove`, which is faster but can swap around elements, affecting the order. 

## Implementation Details

In order to implement the lookahead in such a way that works both with consuming contexts and non-consuming shallow-copy contexts, operations had to be wrapped in a type that can sufficiently track this and allow for interactions between them.

This is done with `MarkedOperation`, implemented like so:

```rust
pub(crate) struct MarkedOperation<K, V> {
    pub op: mem::ManuallyDrop<UnsafeCell<Operation<K, V>>>,
    pub flag: Cell<u32>,
}

const NONE_FLAG: u32 = 0; // value has not been used at all
const FIRST_FLAG: u32 = 1; // value has been used without consuming
const SECOND_FLAG: u32 = 2; // value has been consumed
```

with operations such as:

<details>
<summary>click here to see implementation code</summary>

```rust
impl<K, V> Drop for MarkedOperation<K, V> {
    fn drop(&mut self) {
        // If the operation hasn't been consumed, drop it
        match self.flag.get() {
            NONE_FLAG | FIRST_FLAG => unsafe {
                mem::ManuallyDrop::drop(&mut self.op);
            },
            _ => {}
        }
    }
}

impl<K, V> MarkedOperation<K, V> {
    #[inline(always)]
    pub fn as_ref(&self) -> Option<&Operation<K, V>> {
        match self.flag.get() {
            NONE_FLAG => Some(unsafe { &*self.op.get() }),
            _ => None,
        }
    }

    #[inline(always)]
    pub fn take_second(&self) -> Option<Operation<K, V>> {
        match self.flag.get() {
            SECOND_FLAG => None,
            _ => {
                self.flag.set(SECOND_FLAG);

                Some(unsafe { ptr::read(self.op.get()) })
            }
        }
    }
}
```
</details>


While those may have unsafe code in them, the flag prevents any undefined behavior from occurring, and allowing for a more complex lifecycle for the internal value, with zero overhead besides the flag itself.

While it would be technically possible to emulate this with `Option`s and a boolean, that is effectively splitting the `flag` into two variables, and adding unnecessary overhead both in the compiled code and the number of nested `match` statements that must be used. It gets pretty messy, up to two or three match statements doing the exact same thing, just to get to the inner values. With `MarkedOperation`, it is a single `match` statement. 

All `unsafe` code is sufficiently compartmentalized and accounted for.

## In summary

I think this will have significant impact with applications that use complex keys, and provide the necessary flexibility I've been needing for my own applications. Even for simple integer keys, the low additional overhead provided by `MarkedOperation` and the lookahead should be negligible. 

In-depth benchmarks are planned, certainly. 

A quick test with Noria (of which I'm not too familiar with) yielded around 20%-40% latency improvements, e.g. 50000µs down to 30000µs for 100% read/write results on the "vote" benchmark.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-evmap/13)
<!-- Reviewable:end -->
