### PR TITLE
Feature for amortized resizes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,11 +7,22 @@ stages:
         dir: "left-right"
  - stage: evmap
    jobs:
-    - template: default.yml@templates
+    - template: nightly-only.yml@templates
       parameters:
-        minrust: 1.40.0
         codecov_token: $(CODECOV_TOKEN_SECRET)
         dir: "evmap"
+    - job: features
+      displayName: "Check feature combinations"
+      pool:
+        vmImage: ubuntu-latest
+      steps:
+        - template: install-rust.yml@templates
+          parameters:
+            rust: nightly
+        - script: cargo install cargo-hack
+          displayName: install cargo-hack
+        - script: cargo hack --feature-powerset check
+          displayName: cargo hack
     - job: benchmark
       displayName: "Check that benchmark compiles"
       pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,22 +7,11 @@ stages:
         dir: "left-right"
  - stage: evmap
    jobs:
-    - template: nightly-only.yml@templates
+    - template: default.yml@templates
       parameters:
+        minrust: 1.48.0
         codecov_token: $(CODECOV_TOKEN_SECRET)
         dir: "evmap"
-    - job: features
-      displayName: "Check feature combinations"
-      pool:
-        vmImage: ubuntu-latest
-      steps:
-        - template: install-rust.yml@templates
-          parameters:
-            rust: nightly
-        - script: cargo install cargo-hack
-          displayName: install cargo-hack
-        - script: cargo hack --feature-powerset check
-          displayName: cargo hack
     - job: benchmark
       displayName: "Check that benchmark compiles"
       pool:

--- a/evmap/Cargo.toml
+++ b/evmap/Cargo.toml
@@ -20,11 +20,13 @@ maintenance = { status = "passively-maintained" }
 default = []
 indexed = ["indexmap"]
 eviction = ["indexed", "rand"]
+amortize = ["indexmap-amortized", "hashbag/amortize"]
 
 [dependencies]
 indexmap = { version = "1.1.0", optional = true }
+indexmap-amortized = { version = "1.0.0", optional = true }
 smallvec = "1.0.0"
-hashbag = "0.1.2"
+hashbag = "0.1.3"
 rand = { version = "0.7", default-features = false, features = ["alloc"], optional = true }
 left-right = { version = "0.11.0" } #, path = "../left-right", }
 

--- a/evmap/Cargo.toml
+++ b/evmap/Cargo.toml
@@ -23,8 +23,8 @@ eviction = ["indexed", "rand"]
 amortize = ["indexmap-amortized", "hashbag/amortize"]
 
 [dependencies]
-indexmap = { version = "1.1.0", optional = true }
-indexmap-amortized = { version = "1.0.0", optional = true }
+indexmap = { version = "1.6.1", optional = true }
+indexmap-amortized = { version = "1.6.1", optional = true }
 smallvec = "1.0.0"
 hashbag = "0.1.3"
 rand = { version = "0.7", default-features = false, features = ["alloc"], optional = true }

--- a/evmap/src/inner.rs
+++ b/evmap/src/inner.rs
@@ -1,10 +1,12 @@
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
 
-#[cfg(feature = "indexed")]
-pub(crate) use indexmap::IndexMap as MapImpl;
-#[cfg(not(feature = "indexed"))]
-pub(crate) use std::collections::HashMap as MapImpl;
+#[cfg(all(feature = "indexed", not(feature = "amortize")))]
+pub(crate) use indexmap::{map::Entry, IndexMap as MapImpl};
+#[cfg(feature = "amortize")]
+pub(crate) use indexmap_amortized::{map::Entry, IndexMap as MapImpl};
+#[cfg(not(any(feature = "indexed", feature = "amortize")))]
+pub(crate) use std::collections::{hash_map::Entry, HashMap as MapImpl};
 
 use crate::values::ValuesInner;
 use left_right::aliasing::DropBehavior;

--- a/evmap/src/lib.rs
+++ b/evmap/src/lib.rs
@@ -28,6 +28,16 @@
 //! meta will also be made visible to readers. This could be useful, for example, to indicate what
 //! time the refresh happened.
 //!
+//! # Features
+//!
+//!  - `eviction`: Gives you access to [`WriteHandle::empty_random`] to empty out randomly chosen
+//!    keys from the map.
+//!  - `amortize`: Amortizes the cost of resizes in the underlying data structures. See
+//!    [`griddle`](https://github.com/jonhoo/griddle/) and
+//!    [`atone`](https://github.com/jonhoo/atone/) for details. This requires a nightly compiler
+//!    [for the time being](https://docs.rs/indexmap-amortized/1.0/indexmap_amortized/#rust-version).
+//!
+//!
 //! # Examples
 //!
 //! Single-reader, single-writer

--- a/evmap/src/write.rs
+++ b/evmap/src/write.rs
@@ -1,4 +1,4 @@
-use crate::inner::Inner;
+use crate::inner::{Entry, Inner};
 use crate::read::ReadHandle;
 use crate::values::ValuesInner;
 use left_right::{aliasing::Aliased, Absorb};
@@ -6,11 +6,6 @@ use left_right::{aliasing::Aliased, Absorb};
 use std::collections::hash_map::RandomState;
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
-
-#[cfg(feature = "indexed")]
-use indexmap::map::Entry;
-#[cfg(not(feature = "indexed"))]
-use std::collections::hash_map::Entry;
 
 /// A handle that may be used to modify the eventually consistent map.
 ///


### PR DESCRIPTION
Keep in mind that since this is a feature, _all_ evmap instances get amortized if _anything_ in the dependency graph enables the feature (https://github.com/bluss/indexmap/pull/137#issuecomment-662701746). This is unfortunate, but given that the alternative is forking evmap, we'll go with the feature approach for now. Hopefully one day we'll have a way to [avoid this](https://github.com/rust-lang/cargo/issues/2980#issuecomment-667207117).

Not landing this yet since it's nightly-only at the moment due to certain methods [in `atone`](https://github.com/jonhoo/atone/blob/45ae1e42deaaaaa9a919957ade49982a7ac4655b/src/lib.rs#L58). Nightly-only will go away once https://github.com/rust-lang/rust/issues/70929 and https://github.com/rust-lang/rust/issues/74217 both stabilize. The first one will land on next stable, but the second has some more time to go first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-evmap/66)
<!-- Reviewable:end -->
