### PR TITLE
Add infrastructure for `loom` tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ categories = ["concurrency"]
 
 [dependencies]
 slab = "0.4"
+
+[target.'cfg(loom)'.dependencies]
+loom = "0.4.0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,17 @@ jobs:
      - script: |
            env RUSTFLAGS="-Z sanitizer=leak" cargo test --target x86_64-unknown-linux-gnu
        displayName: cargo -Z sanitizer=leak test
+ - job: loom
+   displayName: "Loom tests"
+   pool:
+     vmImage: ubuntu-latest
+   steps:
+     - template: install-rust.yml@templates
+       parameters:
+         rust: nightly
+     - script: |
+           env RUSTFLAGS="--cfg loom" cargo test --test loom
+       displayName: cargo test loom
 
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
        parameters:
          rust: nightly
      - script: |
-           env RUSTFLAGS="--cfg loom" cargo test --test loom
+           env LOOM_MAX_PREEMPTIONS=3 RUSTFLAGS="--cfg loom" cargo test --test loom
        displayName: cargo test loom
 
 resources:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,9 +174,11 @@
 )]
 #![allow(clippy::type_complexity)]
 
-use std::sync::{atomic, Arc, Mutex};
+mod sync;
 
-type Epochs = Arc<Mutex<slab::Slab<Arc<atomic::AtomicUsize>>>>;
+use crate::sync::{Arc, AtomicUsize, Mutex};
+
+type Epochs = Arc<Mutex<slab::Slab<Arc<AtomicUsize>>>>;
 
 mod write;
 pub use crate::write::WriteHandle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,6 +296,3 @@ where
     let w = WriteHandle::new(T::default(), epochs, r.clone());
     (w, r)
 }
-
-#[cfg(test)]
-mod utilities;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,21 +298,4 @@ where
 }
 
 #[cfg(test)]
-struct CounterAddOp(i32);
-
-#[cfg(test)]
-impl Absorb<CounterAddOp> for i32 {
-    fn absorb_first(&mut self, operation: &mut CounterAddOp, _: &Self) {
-        *self += operation.0;
-    }
-
-    fn absorb_second(&mut self, operation: CounterAddOp, _: &Self) {
-        *self += operation.0;
-    }
-
-    fn drop_first(self: Box<Self>) {}
-
-    fn sync_with(&mut self, first: &Self) {
-        *self = *first
-    }
-}
+mod utilities;

--- a/src/read.rs
+++ b/src/read.rs
@@ -211,7 +211,7 @@ impl<T> ReadHandle<T> {
 ///
 /// // the line below will not compile as ReadHandle does not implement Sync
 ///
-/// is_<ReadHandle<u64>>()
+/// is_sync::<ReadHandle<u64>>()
 /// ```
 ///
 /// But, it can be sent across threads:

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,10 +1,8 @@
+use crate::sync::{fence, Arc, AtomicPtr, AtomicUsize, Ordering};
 use std::cell::Cell;
 use std::fmt;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
-use std::sync::atomic;
-use std::sync::atomic::AtomicPtr;
-use std::sync::{self, Arc};
 
 // To make [`WriteHandle`] and friends work.
 #[cfg(doc)]
@@ -39,9 +37,9 @@ pub use factory::ReadHandleFactory;
 /// a [`ReadHandleFactory`]. Note, however, that creating a new handle through either of these
 /// mechanisms _does_ take a lock, and may therefore become a bottleneck if you do it frequently.
 pub struct ReadHandle<T> {
-    pub(crate) inner: sync::Arc<AtomicPtr<T>>,
+    pub(crate) inner: Arc<AtomicPtr<T>>,
     pub(crate) epochs: crate::Epochs,
-    epoch: sync::Arc<sync::atomic::AtomicUsize>,
+    epoch: Arc<AtomicUsize>,
     epoch_i: usize,
     enters: Cell<usize>,
 
@@ -74,23 +72,20 @@ impl<T> fmt::Debug for ReadHandle<T> {
 
 impl<T> Clone for ReadHandle<T> {
     fn clone(&self) -> Self {
-        ReadHandle::new_with_arc(
-            sync::Arc::clone(&self.inner),
-            sync::Arc::clone(&self.epochs),
-        )
+        ReadHandle::new_with_arc(Arc::clone(&self.inner), Arc::clone(&self.epochs))
     }
 }
 
 impl<T> ReadHandle<T> {
     pub(crate) fn new(inner: T, epochs: crate::Epochs) -> Self {
         let store = Box::into_raw(Box::new(inner));
-        let inner = sync::Arc::new(AtomicPtr::new(store));
+        let inner = Arc::new(AtomicPtr::new(store));
         Self::new_with_arc(inner, epochs)
     }
 
     fn new_with_arc(inner: Arc<AtomicPtr<T>>, epochs: crate::Epochs) -> Self {
         // tell writer about our epoch tracker
-        let epoch = sync::Arc::new(atomic::AtomicUsize::new(0));
+        let epoch = Arc::new(AtomicUsize::new(0));
         // okay to lock, since we're not holding up the epoch
         let epoch_i = epochs.lock().unwrap().insert(Arc::clone(&epoch));
 
@@ -117,7 +112,7 @@ impl<T> ReadHandle<T> {
         if enters != 0 {
             // We have already locked the epoch.
             // Just give out another guard.
-            let r_handle = self.inner.load(atomic::Ordering::Acquire);
+            let r_handle = self.inner.load(Ordering::Acquire);
             // since we previously bumped our epoch, this pointer will remain valid until we bump
             // it again, which only happens when the last ReadGuard is dropped.
             let r_handle = unsafe { r_handle.as_ref() };
@@ -161,13 +156,13 @@ impl<T> ReadHandle<T> {
         // in all cases, using a pointer we read *after* updating our epoch is safe.
 
         // so, update our epoch tracker.
-        self.epoch.fetch_add(1, atomic::Ordering::AcqRel);
+        self.epoch.fetch_add(1, Ordering::AcqRel);
 
         // ensure that the pointer read happens strictly after updating the epoch
-        atomic::fence(atomic::Ordering::SeqCst);
+        fence(Ordering::SeqCst);
 
         // then, atomically read pointer, and use the copy being pointed to
-        let r_handle = self.inner.load(atomic::Ordering::Acquire);
+        let r_handle = self.inner.load(Ordering::Acquire);
 
         // since we bumped our epoch, this pointer will remain valid until we bump it again
         let r_handle = unsafe { r_handle.as_ref() };
@@ -183,14 +178,14 @@ impl<T> ReadHandle<T> {
         } else {
             // the writehandle has been dropped, and so has both copies,
             // so restore parity and return None
-            self.epoch.fetch_add(1, atomic::Ordering::AcqRel);
+            self.epoch.fetch_add(1, Ordering::AcqRel);
             None
         }
     }
 
     /// Returns true if the [`WriteHandle`] has been dropped.
     pub fn was_dropped(&self) -> bool {
-        self.inner.load(atomic::Ordering::Acquire).is_null()
+        self.inner.load(Ordering::Acquire).is_null()
     }
 
     /// Returns a raw pointer to the read copy of the data.
@@ -201,7 +196,7 @@ impl<T> ReadHandle<T> {
     ///
     /// Casting this pointer to `&mut` is never safe.
     pub fn raw_handle(&self) -> Option<NonNull<T>> {
-        NonNull::new(self.inner.load(atomic::Ordering::Acquire))
+        NonNull::new(self.inner.load(Ordering::Acquire))
     }
 }
 
@@ -216,7 +211,7 @@ impl<T> ReadHandle<T> {
 ///
 /// // the line below will not compile as ReadHandle does not implement Sync
 ///
-/// is_sync::<ReadHandle<u64>>()
+/// is_<ReadHandle<u64>>()
 /// ```
 ///
 /// But, it can be sent across threads:

--- a/src/read/factory.rs
+++ b/src/read/factory.rs
@@ -1,6 +1,6 @@
 use super::ReadHandle;
-use std::sync::atomic::AtomicPtr;
-use std::{fmt, sync};
+use crate::sync::{Arc, AtomicPtr};
+use std::fmt;
 
 /// A type that is both `Sync` and `Send` and lets you produce new [`ReadHandle`] instances.
 ///
@@ -9,7 +9,7 @@ use std::{fmt, sync};
 /// that this _internally_ takes a lock whenever you call [`ReadHandleFactory::handle`], so
 /// you should not expect producing new handles rapidly to scale well.
 pub struct ReadHandleFactory<T> {
-    pub(super) inner: sync::Arc<AtomicPtr<T>>,
+    pub(super) inner: Arc<AtomicPtr<T>>,
     pub(super) epochs: crate::Epochs,
 }
 
@@ -24,8 +24,8 @@ impl<T> fmt::Debug for ReadHandleFactory<T> {
 impl<T> Clone for ReadHandleFactory<T> {
     fn clone(&self) -> Self {
         Self {
-            inner: sync::Arc::clone(&self.inner),
-            epochs: sync::Arc::clone(&self.epochs),
+            inner: Arc::clone(&self.inner),
+            epochs: Arc::clone(&self.epochs),
         }
     }
 }
@@ -34,9 +34,6 @@ impl<T> ReadHandleFactory<T> {
     /// Produce a new [`ReadHandle`] to the same left-right data structure as this factory was
     /// originally produced from.
     pub fn handle(&self) -> ReadHandle<T> {
-        ReadHandle::new_with_arc(
-            sync::Arc::clone(&self.inner),
-            sync::Arc::clone(&self.epochs),
-        )
+        ReadHandle::new_with_arc(Arc::clone(&self.inner), Arc::clone(&self.epochs))
     }
 }

--- a/src/read/guard.rs
+++ b/src/read/guard.rs
@@ -1,11 +1,10 @@
+use crate::sync::{AtomicUsize, Ordering};
 use std::cell::Cell;
 use std::mem;
-use std::sync;
-use std::sync::atomic;
 
 #[derive(Debug, Copy, Clone)]
 pub(super) struct ReadHandleState<'rh> {
-    pub(super) epoch: &'rh sync::atomic::AtomicUsize,
+    pub(super) epoch: &'rh AtomicUsize,
     pub(super) enters: &'rh Cell<usize>,
 }
 
@@ -121,7 +120,7 @@ impl<'rh, T: ?Sized> Drop for ReadGuard<'rh, T> {
         self.handle.enters.set(enters);
         if enters == 0 {
             // We are the last guard to be dropped -- now release our epoch.
-            self.handle.epoch.fetch_add(1, atomic::Ordering::AcqRel);
+            self.handle.epoch.fetch_add(1, Ordering::AcqRel);
         }
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,22 @@
+#[cfg(loom)]
+pub(crate) use loom::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+#[cfg(loom)]
+pub(crate) use loom::sync::{Arc, Mutex, MutexGuard};
+#[cfg(loom)]
+pub(crate) fn fence(ord: Ordering) {
+    if let Ordering::Acquire = ord {
+    } else {
+        // FIXME: loom only supports acquire fences at the moment.
+        // https://github.com/tokio-rs/loom/issues/117
+        // let's at least not panic...
+        // this may generate some false positives (`SeqCst` is stronger than `Acquire`
+        // for example), and some false negatives (`Relaxed` is weaker than `Acquire`),
+        // but it's the best we can do for the time being.
+    }
+    loom::sync::atomic::fence(Ordering::Acquire)
+}
+
+#[cfg(not(loom))]
+pub(crate) use std::sync::atomic::{fence, AtomicPtr, AtomicUsize, Ordering};
+#[cfg(not(loom))]
+pub(crate) use std::sync::{Arc, Mutex, MutexGuard};

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,7 +1,3 @@
-#[cfg(not(loom))]
-#[cfg(test)]
-use crate::Absorb;
-
 #[cfg(test)]
 #[derive(Debug)]
 pub struct CounterAddOp(pub i32);

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,0 +1,24 @@
+#[cfg(not(loom))]
+#[cfg(test)]
+use crate::Absorb;
+
+#[cfg(test)]
+#[derive(Debug)]
+pub struct CounterAddOp(pub i32);
+
+#[cfg(test)]
+impl Absorb<CounterAddOp> for i32 {
+    fn absorb_first(&mut self, operation: &mut CounterAddOp, _: &Self) {
+        *self += operation.0;
+    }
+
+    fn absorb_second(&mut self, operation: CounterAddOp, _: &Self) {
+        *self += operation.0;
+    }
+
+    fn drop_first(self: Box<Self>) {}
+
+    fn sync_with(&mut self, first: &Self) {
+        *self = *first
+    }
+}

--- a/src/write.rs
+++ b/src/write.rs
@@ -172,6 +172,9 @@ where
                         thread::yield_now();
                     }
 
+                    #[cfg(loom)]
+                    loom::thread::yield_now();
+
                     continue 'retry;
                 }
             }

--- a/src/write.rs
+++ b/src/write.rs
@@ -166,6 +166,7 @@ where
                     starti = ii;
 
                     // how eagerly should we retry?
+                    #[cfg(not(loom))]
                     if iter != 20 {
                         iter += 1;
                     } else {

--- a/src/write.rs
+++ b/src/write.rs
@@ -430,7 +430,8 @@ struct CheckWriteHandleSend;
 
 #[cfg(test)]
 mod tests {
-    use crate::CounterAddOp;
+    use crate::Absorb;
+    include!("./utilities.rs");
 
     #[test]
     fn append_test() {

--- a/src/write.rs
+++ b/src/write.rs
@@ -165,12 +165,13 @@ where
                     // continue from this reader's epoch
                     starti = ii;
 
-                    // how eagerly should we retry?
-                    #[cfg(not(loom))]
-                    if iter != 20 {
-                        iter += 1;
-                    } else {
-                        thread::yield_now();
+                    if !cfg!(loom) {
+                        // how eagerly should we retry?
+                        if iter != 20 {
+                            iter += 1;
+                        } else {
+                            thread::yield_now();
+                        }
                     }
 
                     #[cfg(loom)]

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,0 +1,47 @@
+#[cfg(loom)]
+#[cfg(test)]
+mod loom_tests {
+    use left_right::{Absorb, ReadGuard};
+    use loom::sync::atomic::AtomicUsize;
+    use loom::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+    use loom::sync::Arc;
+    use loom::thread;
+
+    // TODO Would love to not re-define this!
+    struct CounterAddOp(i32);
+
+    impl Absorb<CounterAddOp> for i32 {
+        fn absorb_first(&mut self, operation: &mut CounterAddOp, _: &Self) {
+            *self += operation.0;
+        }
+
+        fn absorb_second(&mut self, operation: CounterAddOp, _: &Self) {
+            *self += operation.0;
+        }
+
+        fn drop_first(self: Box<Self>) {}
+
+        fn sync_with(&mut self, first: &Self) {
+            *self = *first
+        }
+    }
+
+    #[test]
+    fn read_before_publish() {
+        loom::model(|| {
+            let (mut w, r) = left_right::new::<i32, _>();
+            w.append(CounterAddOp(1));
+            w.publish();
+
+            let val = *r.enter().unwrap();
+
+            let jh = thread::spawn(move || {
+                w.append(CounterAddOp(1));
+                w.publish();
+            });
+            jh.join().unwrap();
+
+            assert_eq!(1, val);
+        });
+    }
+}

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,30 +1,16 @@
 #[cfg(loom)]
 #[cfg(test)]
 mod loom_tests {
-    use left_right::{Absorb, ReadGuard};
+    // Evil hack to share CounterAddOp between
+    // unit tests and integration tests.
+    use left_right::Absorb;
+    include!("../src/utilities.rs");
+
+    use left_right::ReadGuard;
     use loom::sync::atomic::AtomicUsize;
     use loom::sync::atomic::Ordering::{Acquire, Relaxed, Release};
     use loom::sync::Arc;
     use loom::thread;
-
-    // TODO Would love to not re-define this!
-    struct CounterAddOp(i32);
-
-    impl Absorb<CounterAddOp> for i32 {
-        fn absorb_first(&mut self, operation: &mut CounterAddOp, _: &Self) {
-            *self += operation.0;
-        }
-
-        fn absorb_second(&mut self, operation: CounterAddOp, _: &Self) {
-            *self += operation.0;
-        }
-
-        fn drop_first(self: Box<Self>) {}
-
-        fn sync_with(&mut self, first: &Self) {
-            *self = *first
-        }
-    }
 
     #[test]
     fn read_before_publish() {

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -6,25 +6,33 @@ mod loom_tests {
     use left_right::Absorb;
     include!("../src/utilities.rs");
 
+    use loom::sync::atomic::{AtomicI32, Ordering};
+    use loom::sync::Arc;
     use loom::thread;
 
     #[test]
     fn read_before_publish() {
         loom::model(|| {
             let (mut w, r) = left_right::new::<i32, _>();
+            let answer = Arc::new(AtomicI32::new(0));
+            let answer_clone = answer.clone();
+
             w.append(CounterAddOp(1));
             w.publish();
 
             let jh = thread::spawn(move || {
-                w.publish();
-                w.append(CounterAddOp(1));
+                let val = *r.enter().unwrap();
+                answer_clone.store(val, Ordering::SeqCst);
             });
-
-            let val = *r.enter().unwrap();
+            w.publish();
+            w.append(CounterAddOp(1));
 
             jh.join().unwrap();
 
-            assert_eq!(1, val);
+            // This is just to ensure the write handle is not dropped before the reader reads
+            w.flush();
+
+            assert_eq!(1, answer.load(Ordering::SeqCst));
         });
     }
 }

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -6,10 +6,6 @@ mod loom_tests {
     use left_right::Absorb;
     include!("../src/utilities.rs");
 
-    use left_right::ReadGuard;
-    use loom::sync::atomic::AtomicUsize;
-    use loom::sync::atomic::Ordering::{Acquire, Relaxed, Release};
-    use loom::sync::Arc;
     use loom::thread;
 
     #[test]

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -6,33 +6,26 @@ mod loom_tests {
     use left_right::Absorb;
     include!("../src/utilities.rs");
 
-    use loom::sync::atomic::{AtomicI32, Ordering};
-    use loom::sync::Arc;
     use loom::thread;
 
     #[test]
     fn read_before_publish() {
         loom::model(|| {
             let (mut w, r) = left_right::new::<i32, _>();
-            let answer = Arc::new(AtomicI32::new(0));
-            let answer_clone = answer.clone();
 
             w.append(CounterAddOp(1));
             w.publish();
 
-            let jh = thread::spawn(move || {
-                let val = *r.enter().unwrap();
-                answer_clone.store(val, Ordering::SeqCst);
-            });
+            let jh = thread::spawn(move || *r.enter().unwrap());
+
             w.publish();
             w.append(CounterAddOp(1));
-
-            jh.join().unwrap();
 
             // This is just to ensure the write handle is not dropped before the reader reads
             w.flush();
+            let val = jh.join().unwrap();
 
-            assert_eq!(1, answer.load(Ordering::SeqCst));
+            assert_eq!(1, val);
         });
     }
 }

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -33,12 +33,13 @@ mod loom_tests {
             w.append(CounterAddOp(1));
             w.publish();
 
+            let jh = thread::spawn(move || {
+                w.publish();
+                w.append(CounterAddOp(1));
+            });
+
             let val = *r.enter().unwrap();
 
-            let jh = thread::spawn(move || {
-                w.append(CounterAddOp(1));
-                w.publish();
-            });
             jh.join().unwrap();
 
             assert_eq!(1, val);

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -21,8 +21,6 @@ mod loom_tests {
             w.publish();
             w.append(CounterAddOp(1));
 
-            // This is just to ensure the write handle is not dropped before the reader reads
-            w.flush();
             let val = jh.join().unwrap();
 
             assert_eq!(1, val);


### PR DESCRIPTION
**This Commit**
Sets up testing with the `loom` infrastructure by doing three things:
1. creating a `mod sync` that exports `std` or `loom` versions of
concurrency primitives depending on the configuration flags (as
recommended by [the `loom` docs][1]).
2. changing all imports of the various std::sync::* concurrency
primitives to crate::sync::* so that we can toggle to `loom`
primitives from `std` lib primitives when testing
3. writing a bare-bones loom test for others to build upon :-)

Related to #17 

[1]: https://github.com/tokio-rs/loom#structuring-tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/left-right/91)
<!-- Reviewable:end -->
