### PR TITLE
add WriteHandle::take using take_inner

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@ type Epochs = Arc<Mutex<slab::Slab<Arc<AtomicUsize>>>>;
 
 mod write;
 pub use crate::write::WriteHandle;
+pub use crate::write::Taken;
 
 mod read;
 pub use crate::read::{ReadGuard, ReadHandle, ReadHandleFactory};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,8 +181,8 @@ use crate::sync::{Arc, AtomicUsize, Mutex};
 type Epochs = Arc<Mutex<slab::Slab<Arc<AtomicUsize>>>>;
 
 mod write;
-pub use crate::write::WriteHandle;
 pub use crate::write::Taken;
+pub use crate::write::WriteHandle;
 
 mod read;
 pub use crate::read::{ReadGuard, ReadHandle, ReadHandleFactory};

--- a/src/write.rs
+++ b/src/write.rs
@@ -392,7 +392,7 @@ where
     /// assert_eq!(original_data, taken_data);
     ///
     /// // make sure it is dropped using `drop_second` if your type requires it.
-    /// Absorb::drop_second(Box::new(taken_data));
+    /// BackingData::drop_second(Box::new(taken_data));
     /// ```
     ///
     /// Another option is to edit the `Drop` implementation of your `T`.

--- a/src/write.rs
+++ b/src/write.rs
@@ -75,9 +75,9 @@ where
 }
 
 /// A **smart pointer** to an owned backing data structure. This makes sure that the
-/// data is dropped correctly. (Using `Absorb::drop_second`)
+/// data is dropped correctly (using [`Absorb::drop_second`]).
 ///
-/// Additionally it allows for unsafely getting the inner data out using `.into_box()`
+/// Additionally it allows for unsafely getting the inner data out using [`into_box()`](AbsorbDrop::into_box).
 pub struct AbsorbDrop<T: Absorb<O>, O> {
     inner: Option<Box<T>>,
     _marker: PhantomData<O>,
@@ -115,11 +115,11 @@ impl<T: Absorb<O>, O> DerefMut for AbsorbDrop<T, O> {
 }
 
 impl<T: Absorb<O>, O> AbsorbDrop<T, O> {
-    /// This is unsafe because you must call `Absorb::drop_second` in
-    /// case just dropping `T` would not be safe and sufficient.
+    /// This is unsafe because you must call [`Absorb::drop_second`] in
+    /// case just dropping `T` is not safe and sufficient.
     ///
-    /// If you used the default implementation of `Absorb::drop_second` (which just calls `drop`)
-    /// you don't need to use `Absorb::drop_second`.
+    /// If you used the default implementation of [`Absorb::drop_second`] (which just calls [`drop`](Drop::drop))
+    /// you don't need to call [`Absorb::drop_second`].
     pub unsafe fn into_box(mut self) -> Box<T> {
         self.inner
             .take()
@@ -142,8 +142,8 @@ where
     /// Takes out the inner backing data structure if it hasn't been taken yet. Otherwise returns `None`.
     ///
     /// Makes sure that all the pending operations are applied and waits till all the read handles
-    /// have departed. Then it uses `Absorb::drop_first` to drop one of the copies of the data and
-    /// returns the other copy as an `AbsorbDrop` smart pointer.
+    /// have departed. Then it uses [`Absorb::drop_first`] to drop one of the copies of the data and
+    /// returns the other copy as an [`AbsorbDrop`] smart pointer.
     fn take_inner(&mut self) -> Option<AbsorbDrop<T, O>> {
         use std::ptr;
         // Can only take inner once.
@@ -429,8 +429,8 @@ where
     /// Returns the backing data structure.
     ///
     /// Makes sure that all the pending operations are applied and waits till all the read handles
-    /// have departed. Then it uses `Absorb::drop_first` to drop one of the copies of the data and
-    /// returns the other copy as an `AbsorbDrop` smart pointer.
+    /// have departed. Then it uses [`Absorb::drop_first`] to drop one of the copies of the data and
+    /// returns the other copy as an [`AbsorbDrop`] smart pointer.
     pub fn take(mut self) -> AbsorbDrop<T, O> {
         // It is always safe to `expect` here because `take_inner` is private
         // and it is only called here and in the drop impl. Since we have an owned

--- a/src/write.rs
+++ b/src/write.rs
@@ -543,17 +543,25 @@ mod tests {
 
     #[test]
     fn take_test() {
+        // normal publish then pending operations published by take
         let (mut w, _r) = crate::new_from_empty::<i32, _>(2);
         w.append(CounterAddOp(1));
         w.publish();
         w.append(CounterAddOp(1));
         assert_eq!(w.take(), 4);
 
+        // pending operations published by take
         let (mut w, _r) = crate::new_from_empty::<i32, _>(2);
         w.append(CounterAddOp(1));
-        // w.publish();
         assert_eq!(w.take(), 3);
 
+        // emptry op queue
+        let (mut w, _r) = crate::new_from_empty::<i32, _>(2);
+        w.append(CounterAddOp(1));
+        w.publish();
+        assert_eq!(w.take(), 3);
+
+        // no operations
         let (w, _r) = crate::new_from_empty::<i32, _>(2);
         assert_eq!(w.take(), 2);
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -579,6 +579,23 @@ mod tests {
 
     #[test]
     fn take_test() {
+        // publish twice then take with no pending operations
+        let (mut w, _r) = crate::new_from_empty::<i32, _>(2);
+        w.append(CounterAddOp(1));
+        w.publish();
+        w.append(CounterAddOp(1));
+        w.publish();
+        assert_eq!(*w.take(), 4);
+
+        // publish twice then pending operation published by take
+        let (mut w, _r) = crate::new_from_empty::<i32, _>(2);
+        w.append(CounterAddOp(1));
+        w.publish();
+        w.append(CounterAddOp(1));
+        w.publish();
+        w.append(CounterAddOp(2));
+        assert_eq!(*w.take(), 6);
+
         // normal publish then pending operations published by take
         let (mut w, _r) = crate::new_from_empty::<i32, _>(2);
         w.append(CounterAddOp(1));

--- a/src/write.rs
+++ b/src/write.rs
@@ -386,7 +386,7 @@ where
     /// # }
     ///
     /// let original_data = BackingData(10);
-    /// let (write, read) = left_right::new_from_empty::<_, CounterAddOp>(original_data.clone());
+    /// let (write, read) = left_right::new_from_empty(original_data.clone());
     ///
     /// let taken_data = write.take();
     /// assert_eq!(original_data, taken_data);


### PR DESCRIPTION
As mentioned in https://github.com/jonhoo/left-right/pull/96#pullrequestreview-651799305:
> add a `take_inner(&mut self) -> Option<T>` that does all the stuff `take`/`drop` currently does. Then, call that from both `drop` and `take`, with `drop` just dropping the return value.

But the `take_inner` in this PR returns an `Option<Box<T>>` which I think is better because:
* `T` is already boxed
* drop_second needs a boxed `T`
* `T` might be large so it might be sometimes faster to pass the boxed T

Still not quite sure about my documentation for `take`..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/left-right/97)
<!-- Reviewable:end -->
