### PR TITLE
Adding missing ReadHandleFactory methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,3 +297,34 @@ where
     let w = WriteHandle::new(T::default(), epochs, r.clone());
     (w, r)
 }
+
+/// Construct a new write randle and read handle factory pair from an empty data structure.
+///
+/// The type must implement `Clone` so we can construct the second copy from the first.
+pub fn new_from_empty_with_factory<T, O>(t: T) -> (WriteHandle<T, O>, ReadHandleFactory<T>)
+where
+    T: Absorb<O> + Clone,
+{
+    let epochs = Default::default();
+
+    let r = ReadHandleFactory::new(t.clone(), Arc::clone(&epochs));
+    let w = WriteHandle::new(t, epochs, r.handle());
+    (w, r)
+}
+
+
+/// Construct a new write randle and read handle factory pair from the data structure default.
+///
+/// The type must implement `Default` so we can construct two empty instances. 
+/// If your type's `Default` implementation does not guarantee this, you can use `new_from_empty_with_factory`,
+/// which relies on `Clone` instead of `Default`.
+pub fn new_with_factory<T, O>() -> (WriteHandle<T, O>, ReadHandleFactory<T>)
+where
+    T: Absorb<O> + Default,
+{
+    let epochs = Default::default();
+
+    let r = ReadHandleFactory::new(T::default(), Arc::clone(&epochs));
+    let w = WriteHandle::new(T::default(), epochs, r.handle());
+    (w, r)
+}

--- a/src/read/factory.rs
+++ b/src/read/factory.rs
@@ -13,6 +13,17 @@ pub struct ReadHandleFactory<T> {
     pub(super) epochs: crate::Epochs,
 }
 
+impl<T> ReadHandleFactory<T> {
+    pub(crate) fn new(inner: T, epochs: crate::Epochs) -> Self {
+        let store = Box::into_raw(Box::new(inner));
+        let inner = Arc::new(AtomicPtr::new(store));
+        Self {
+            inner,
+            epochs
+        }
+    }
+}
+
 impl<T> fmt::Debug for ReadHandleFactory<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ReadHandleFactory")


### PR DESCRIPTION
It seems `ReadHandleFactory` couldn't be used previously as there were no respective crate functions exported. Not sure if that's intended though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/left-right/98)
<!-- Reviewable:end -->
