### PR TITLE
Allow for compression of the oplog in case of mergeable operations.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,10 +290,8 @@ pub trait Absorb<O> {
     ///
     /// Can be used to avoid having [`append`](WriteHandle::append) take O(oplog.len) if it is filled with mainly independent ops.
     ///
-    /// Defaults to `&0`, which disables compression and allows the usage of an efficient fallback.
-    fn max_compress_range() -> &'static usize {
-        &0
-    }
+    /// Defaults to `0`, which disables compression and allows the usage of an efficient fallback.
+    const MAX_COMPRESS_RANGE: usize = 0;
 
     /// Try to compress two ops into a single op to optimize the oplog.
     ///

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -8,13 +8,75 @@ impl Absorb<CounterAddOp> for i32 {
         *self += operation.0;
     }
 
-    fn absorb_second(&mut self, operation: CounterAddOp, _: &Self) {
-        *self += operation.0;
+    fn sync_with(&mut self, first: &Self) {
+        *self = *first
     }
+}
 
-    fn drop_first(self: Box<Self>) {}
+#[cfg(test)]
+#[derive(Debug)]
+pub enum CompressibleCounterOp<const MAX_COMPRESS_RANGE: usize> {
+    Set(i32),
+    Add(i32),
+    Sub(i32),
+}
+
+#[cfg(test)]
+impl<const MAX_COMPRESS_RANGE: usize> Absorb<CompressibleCounterOp<MAX_COMPRESS_RANGE>> for i32 {
+    fn absorb_first(
+        &mut self,
+        operation: &mut CompressibleCounterOp<MAX_COMPRESS_RANGE>,
+        _: &Self,
+    ) {
+        match operation {
+            CompressibleCounterOp::Set(v) => *self = *v,
+            CompressibleCounterOp::Add(v) => *self += *v,
+            CompressibleCounterOp::Sub(v) => *self -= *v,
+        }
+    }
 
     fn sync_with(&mut self, first: &Self) {
         *self = *first
+    }
+
+    fn max_compress_range() -> &'static usize {
+        &MAX_COMPRESS_RANGE
+    }
+
+    fn try_compress(
+        prev: CompressibleCounterOp<MAX_COMPRESS_RANGE>,
+        next: CompressibleCounterOp<MAX_COMPRESS_RANGE>,
+    ) -> TryCompressResult<CompressibleCounterOp<MAX_COMPRESS_RANGE>> {
+        match (prev, next) {
+            (CompressibleCounterOp::Add(prev), CompressibleCounterOp::Add(next)) => {
+                TryCompressResult::Compressed {
+                    result: CompressibleCounterOp::Add(prev + next),
+                }
+            }
+            (CompressibleCounterOp::Sub(prev), CompressibleCounterOp::Sub(next)) => {
+                TryCompressResult::Compressed {
+                    result: CompressibleCounterOp::Sub(prev + next),
+                }
+            }
+            (CompressibleCounterOp::Add(prev), CompressibleCounterOp::Sub(next)) => {
+                TryCompressResult::Independent {
+                    prev: CompressibleCounterOp::Add(prev),
+                    next: CompressibleCounterOp::Sub(next),
+                }
+            }
+            (CompressibleCounterOp::Sub(prev), CompressibleCounterOp::Add(next)) => {
+                TryCompressResult::Independent {
+                    prev: CompressibleCounterOp::Sub(prev),
+                    next: CompressibleCounterOp::Add(next),
+                }
+            }
+            (CompressibleCounterOp::Set(prev), next) => TryCompressResult::Dependent {
+                prev: CompressibleCounterOp::Set(prev),
+                next,
+            },
+            (_, CompressibleCounterOp::Set(next)) => TryCompressResult::Compressed {
+                result: CompressibleCounterOp::Set(next),
+            },
+        }
     }
 }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -39,9 +39,7 @@ impl<const MAX_COMPRESS_RANGE: usize> Absorb<CompressibleCounterOp<MAX_COMPRESS_
         *self = *first
     }
 
-    fn max_compress_range() -> &'static usize {
-        &MAX_COMPRESS_RANGE
-    }
+    const MAX_COMPRESS_RANGE: usize = MAX_COMPRESS_RANGE;
 
     fn try_compress(
         prev: CompressibleCounterOp<MAX_COMPRESS_RANGE>,

--- a/src/write.rs
+++ b/src/write.rs
@@ -484,7 +484,7 @@ where
             }
         } else {
             // Only try to compress if it could actually have an effect, else use original impl as efficient fallback
-            if *T::max_compress_range() > 0 {
+            if T::MAX_COMPRESS_RANGE > 0 {
                 // Compress oplog by rev-iterating all ops appended since the last publish
                 // while attempting to combine them with the next op,
                 // cut short when an attempt fails due to encountering a dependence (e.g. clear then set).
@@ -496,7 +496,7 @@ where
                     // used to more efficiently insert next if possible
                     let mut none: Option<(usize, &mut Option<O>)> = None;
                     // rev-iterate all unpublished ops already in the oplog
-                    let mut range_remaining = *T::max_compress_range();
+                    let mut range_remaining = T::MAX_COMPRESS_RANGE;
 
                     for (prev_rev_idx, prev_loc) in {
                         #[cfg(test)]
@@ -540,7 +540,7 @@ where
                                     // Remember empty loc for efficient insertion
                                     none.replace((prev_rev_idx, prev_loc));
                                     // We successfully compressed ops and therefore reset our range.
-                                    range_remaining = *T::max_compress_range();
+                                    range_remaining = T::MAX_COMPRESS_RANGE;
                                     next = result;
                                     // If the now empty loc is at the back of the non-none oplog we can increment none_back_count.
                                     if prev_rev_idx == none_back_count {


### PR DESCRIPTION
## What
Adds one associated const and fn each to `Absorb`, as well the new Type `TryCompressResult` returned by that fn. Together they allow `WriteHandle::extend` (and by extension `WriteHandle::append`) to optimize the op-log by combining certain operations into one.

## Why
Reading/Watching about left-right/evmap it was mentioned that on top of the base doubling (unless carefully deduplicated) of memory the op-log can get quite out of hand if only infrequently published. That got me thinking about how, in a toy example of a simple map, you could combine set-ops with the same key to be the last one, merge certain modify-ops (like add), and completely consume the op-log when emitting a clear-op. Then I looked at the source and found it quite straightforward to implement. So I did (in about six hours).

## How
When compression is enabled `WriteHandle::extend` reverse-walks the fully unpublished portion of the op-log while attempting to combine ops. It does this by calling `Absorb::try_compress` and either:
 - skipping an empty entry
 - leaving behind an empty entry and continuing on when it returned `TryCompressResult::Compressed`
 - skipping an entry and continuing on when it returned `TryCompressResult::Independent`
 - stopping and inserting the op when it returned `TryCompressResult::Dependent`

After finishing for all ops it then stably moves all empty entries to the end of the op-log before truncating it.

I have also added three complementary optimizations to avoid some pathological worst cases:
 - It keeps track of the first non-empty entry from the back to avoid fully iterating a long but empty op-log in the case of a 'clear' (which consumes everything) being followed by a 'set'
 - It keeps track of its most recently encountered empty entry to avoid unnecessarily growing the op-log when inserting.
 - It stops after getting `Absorb::MAX_COMPRESS_RANGE` `TryCompressResult::Independent`s in a row to avoid iterating the full op-log in case it is filled with predominantly independent ops.

## Caveats
 - Even though they are only temporarily empty during `WriteHandle::extend`, the op-log now contains options instead of values. As ops are basically always enums, enum folding and `opt.unwrap_or_else(|| unreachable!())` should(?) remove any overhead.
 - Probably needs more tests than the ones I have already added.
 - Lots of slow but thorough `debug_assert!(...)`s, which should leave no traces in a release build.

## Is it useful?
Frankly, I don't know. I haven't actually used left-right in any serious projects and so can't really judge if this optimization is worthwhile. However, because compression is controlled via an associated const, it should monomorphize away and so at least not degrade performance when disabled, otherwise, it basically shifts writer-side computation from publishing to extending while potentially saving a fair chunk of memory. (Though come to think of it, it should also be quite straightforward to move the compression into `WriteHandle::publish`, though it then wouldn't be saving any memory, which likely is the main benefit.)
