### PR TITLE
Update loom dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ categories = ["concurrency"]
 slab = "0.4"
 
 [target.'cfg(loom)'.dependencies]
-loom = "0.4.0"
+loom = "0.5.6"


### PR DESCRIPTION
The old version depends on a pre 0.7 generator version that has the
RUSTSEC-2020-0151 advisory issued, causing cargo deny to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/left-right/105)
<!-- Reviewable:end -->
