### PR TITLE
Refactor publish to remove ‘first’ and ‘second’ edge cases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,9 +94,6 @@
 //!     // See the documentation of `Absorb::drop_first`.
 //!     fn drop_first(self: Box<Self>) {}
 //!
-//!     fn sync_with(&mut self, first: &Self) {
-//!         *self = *first
-//!     }
 //! }
 //!
 //! // Now, you can construct a new left-right over an instance of your data structure.
@@ -248,19 +245,6 @@ pub trait Absorb<O> {
     /// Defaults to calling `Self::drop`.
     #[allow(clippy::boxed_local)]
     fn drop_second(self: Box<Self>) {}
-
-    /// Sync the data from `first` into `self`.
-    ///
-    /// To improve initialization performance, before the first call to `publish` changes aren't
-    /// added to the internal oplog, but applied to the first copy directly using `absorb_second`.
-    /// The first `publish` then calls `sync_with` instead of `absorb_second`.
-    ///
-    /// `sync_with` should ensure that `self`'s state exactly matches that of `first` after it
-    /// returns. Be particularly mindful of non-deterministic implementations of traits that are
-    /// often assumed to be deterministic (like `Eq` and `Hash`), and of "hidden states" that
-    /// subtly affect results like the `RandomState` of a `HashMap` which can change iteration
-    /// order.
-    fn sync_with(&mut self, first: &Self);
 }
 
 /// Construct a new write and read handle pair from an empty data structure.

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -14,7 +14,4 @@ impl Absorb<CounterAddOp> for i32 {
 
     fn drop_first(self: Box<Self>) {}
 
-    fn sync_with(&mut self, first: &Self) {
-        *self = *first
-    }
 }

--- a/tests/deque.rs
+++ b/tests/deque.rs
@@ -96,11 +96,6 @@ impl Absorb<Op> for Deque {
         }
     }
 
-    fn sync_with(&mut self, first: &Self) {
-        assert_eq!(self.len(), 0);
-        self.extend(first.iter().map(|v| unsafe { v.alias() }));
-    }
-
     fn drop_first(self: Box<Self>) {
         // The Deque type has NoDrop, so this will not drop any of the values.
     }


### PR DESCRIPTION
**Description**

This PR updates the publish method implementation to no longer treat the first and second publish operations as special cases within the base algorithm. These operations were handled directly rather than being passed through the operation log, introducing conditional branches into the base algorithm.

While this special handling could reduce overhead for initial operations, it added complexity and required synchronization via a dedicated API method. From an API implementor’s perspective, this makes the implementation slightly trickier—ideally, a simple clone() during initialization should be sufficient.

At this point, there is no performance benchmark to validate whether the previous optimization (handling the first two publishes separately) offers meaningful gains. I plan to add benchmarks to compare both approaches and evaluate whether the added complexity is justified.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/left-right/119)
<!-- Reviewable:end -->
